### PR TITLE
Fix misleading zero timing values on failures

### DIFF
--- a/internet-connection-monitor/internal/browser/controller_impl.go
+++ b/internet-connection-monitor/internal/browser/controller_impl.go
@@ -185,6 +185,11 @@ func (c *ControllerImpl) Close() error {
 	return nil
 }
 
+// int64Ptr is a helper function to create a pointer to an int64 value
+func int64Ptr(val int64) *int64 {
+	return &val
+}
+
 // extractTimings converts performance navigation timing data to our metrics structure
 //
 // The browser is configured to force fresh DNS, TCP, and TLS on every test by disabling
@@ -228,39 +233,39 @@ func extractTimings(perfData map[string]interface{}, totalMs int64) models.Timin
 
 	// DNS lookup duration
 	if domainLookupEnd > 0 {
-		timings.DNSLookupMs = int64(domainLookupEnd - domainLookupStart)
+		timings.DNSLookupMs = int64Ptr(int64(domainLookupEnd - domainLookupStart))
 	}
 
 	// TCP connection duration
 	if connectEnd > 0 {
 		if secureConnectionStart > 0 {
 			// For HTTPS: TCP time is from connectStart to secureConnectionStart
-			timings.TCPConnectionMs = int64(secureConnectionStart - connectStart)
+			timings.TCPConnectionMs = int64Ptr(int64(secureConnectionStart - connectStart))
 		} else {
 			// For HTTP: TCP time is the full connection time
-			timings.TCPConnectionMs = int64(connectEnd - connectStart)
+			timings.TCPConnectionMs = int64Ptr(int64(connectEnd - connectStart))
 		}
 	}
 
 	// TLS handshake duration (only for HTTPS connections)
 	if secureConnectionStart > 0 && connectEnd > secureConnectionStart {
-		timings.TLSHandshakeMs = int64(connectEnd - secureConnectionStart)
+		timings.TLSHandshakeMs = int64Ptr(int64(connectEnd - secureConnectionStart))
 	}
 
 	// Time to first byte (TTFB): from request start to response start
 	if responseStart > 0 {
-		timings.TimeToFirstByteMs = int64(responseStart - requestStart)
+		timings.TimeToFirstByteMs = int64Ptr(int64(responseStart - requestStart))
 	}
 
 	// DOM content loaded (when HTML is parsed and DOM is ready)
 	if domContentLoadedEventEnd > 0 {
-		timings.DOMContentLoadedMs = int64(domContentLoadedEventEnd)
+		timings.DOMContentLoadedMs = int64Ptr(int64(domContentLoadedEventEnd))
 	}
 
 	// Full page load (when all resources are loaded)
 	if loadEventEnd > 0 {
-		timings.FullPageLoadMs = int64(loadEventEnd)
-		timings.NetworkIdleMs = int64(loadEventEnd) // Network idle ≈ load complete
+		timings.FullPageLoadMs = int64Ptr(int64(loadEventEnd))
+		timings.NetworkIdleMs = int64Ptr(int64(loadEventEnd)) // Network idle ≈ load complete
 	}
 
 	return timings

--- a/internet-connection-monitor/internal/browser/controller_impl_test.go
+++ b/internet-connection-monitor/internal/browser/controller_impl_test.go
@@ -69,38 +69,38 @@ func TestExtractTimings_HTTPS(t *testing.T) {
 
 	// Verify extraction logic is mathematically correct
 	// DNS lookup: domainLookupEnd - domainLookupStart = 10.5 - 0 = 10ms
-	if timings.DNSLookupMs != 10 {
-		t.Errorf("Expected DNS lookup 10ms, got %d", timings.DNSLookupMs)
+	if timings.DNSLookupMs == nil || *timings.DNSLookupMs != 10 {
+		t.Errorf("Expected DNS lookup 10ms, got %v", timings.DNSLookupMs)
 	}
 
 	// TCP connection: secureConnectionStart - connectStart = 30.1 - 10.5 = 19ms (for HTTPS)
-	if timings.TCPConnectionMs != 19 {
-		t.Errorf("Expected TCP connection 19ms, got %d", timings.TCPConnectionMs)
+	if timings.TCPConnectionMs == nil || *timings.TCPConnectionMs != 19 {
+		t.Errorf("Expected TCP connection 19ms, got %v", timings.TCPConnectionMs)
 	}
 
 	// TLS handshake: connectEnd - secureConnectionStart = 50.2 - 30.1 = 20ms
-	if timings.TLSHandshakeMs != 20 {
-		t.Errorf("Expected TLS handshake 20ms, got %d", timings.TLSHandshakeMs)
+	if timings.TLSHandshakeMs == nil || *timings.TLSHandshakeMs != 20 {
+		t.Errorf("Expected TLS handshake 20ms, got %v", timings.TLSHandshakeMs)
 	}
 
 	// TTFB: responseStart - requestStart
-	if timings.TimeToFirstByteMs != 50 {
-		t.Errorf("Expected TTFB 50ms, got %d", timings.TimeToFirstByteMs)
+	if timings.TimeToFirstByteMs == nil || *timings.TimeToFirstByteMs != 50 {
+		t.Errorf("Expected TTFB 50ms, got %v", timings.TimeToFirstByteMs)
 	}
 
 	// DOM content loaded
-	if timings.DOMContentLoadedMs != 200 {
-		t.Errorf("Expected DOM content loaded 200ms, got %d", timings.DOMContentLoadedMs)
+	if timings.DOMContentLoadedMs == nil || *timings.DOMContentLoadedMs != 200 {
+		t.Errorf("Expected DOM content loaded 200ms, got %v", timings.DOMContentLoadedMs)
 	}
 
 	// Full page load
-	if timings.FullPageLoadMs != 250 {
-		t.Errorf("Expected full page load 250ms, got %d", timings.FullPageLoadMs)
+	if timings.FullPageLoadMs == nil || *timings.FullPageLoadMs != 250 {
+		t.Errorf("Expected full page load 250ms, got %v", timings.FullPageLoadMs)
 	}
 
 	// Network idle (same as load event end)
-	if timings.NetworkIdleMs != 250 {
-		t.Errorf("Expected network idle 250ms, got %d", timings.NetworkIdleMs)
+	if timings.NetworkIdleMs == nil || *timings.NetworkIdleMs != 250 {
+		t.Errorf("Expected network idle 250ms, got %v", timings.NetworkIdleMs)
 	}
 
 	// Total duration (from parameter)
@@ -127,24 +127,24 @@ func TestExtractTimings_HTTP(t *testing.T) {
 	timings := extractTimings(perfData, 220)
 
 	// DNS lookup: 8.3 - 0 = 8ms
-	if timings.DNSLookupMs != 8 {
-		t.Errorf("Expected DNS lookup 8ms, got %d", timings.DNSLookupMs)
+	if timings.DNSLookupMs == nil || *timings.DNSLookupMs != 8 {
+		t.Errorf("Expected DNS lookup 8ms, got %v", timings.DNSLookupMs)
 	}
 
 	// TCP connection: full connection time for HTTP (no TLS)
 	// 25.7 - 8.3 = 17ms
-	if timings.TCPConnectionMs != 17 {
-		t.Errorf("Expected TCP connection 17ms, got %d", timings.TCPConnectionMs)
+	if timings.TCPConnectionMs == nil || *timings.TCPConnectionMs != 17 {
+		t.Errorf("Expected TCP connection 17ms, got %v", timings.TCPConnectionMs)
 	}
 
-	// TLS handshake: should be 0 for HTTP
-	if timings.TLSHandshakeMs != 0 {
-		t.Errorf("Expected TLS handshake 0ms for HTTP, got %d", timings.TLSHandshakeMs)
+	// TLS handshake: should be nil for HTTP (no TLS)
+	if timings.TLSHandshakeMs != nil {
+		t.Errorf("Expected TLS handshake nil for HTTP, got %v", timings.TLSHandshakeMs)
 	}
 
 	// TTFB
-	if timings.TimeToFirstByteMs != 49 {
-		t.Errorf("Expected TTFB 49ms, got %d", timings.TimeToFirstByteMs)
+	if timings.TimeToFirstByteMs == nil || *timings.TimeToFirstByteMs != 49 {
+		t.Errorf("Expected TTFB 49ms, got %v", timings.TimeToFirstByteMs)
 	}
 }
 
@@ -152,18 +152,18 @@ func TestExtractTimings_HTTP(t *testing.T) {
 func TestExtractTimings_NullData(t *testing.T) {
 	timings := extractTimings(nil, 500)
 
-	// All timings should be 0 except total duration
-	if timings.DNSLookupMs != 0 {
-		t.Errorf("Expected DNS lookup 0ms for nil data, got %d", timings.DNSLookupMs)
+	// All timings should be nil for missing data (not 0)
+	if timings.DNSLookupMs != nil {
+		t.Errorf("Expected DNS lookup nil for nil data, got %v", timings.DNSLookupMs)
 	}
-	if timings.TCPConnectionMs != 0 {
-		t.Errorf("Expected TCP connection 0ms for nil data, got %d", timings.TCPConnectionMs)
+	if timings.TCPConnectionMs != nil {
+		t.Errorf("Expected TCP connection nil for nil data, got %v", timings.TCPConnectionMs)
 	}
-	if timings.TLSHandshakeMs != 0 {
-		t.Errorf("Expected TLS handshake 0ms for nil data, got %d", timings.TLSHandshakeMs)
+	if timings.TLSHandshakeMs != nil {
+		t.Errorf("Expected TLS handshake nil for nil data, got %v", timings.TLSHandshakeMs)
 	}
-	if timings.TimeToFirstByteMs != 0 {
-		t.Errorf("Expected TTFB 0ms for nil data, got %d", timings.TimeToFirstByteMs)
+	if timings.TimeToFirstByteMs != nil {
+		t.Errorf("Expected TTFB nil for nil data, got %v", timings.TimeToFirstByteMs)
 	}
 
 	// Total duration should still be set
@@ -177,9 +177,9 @@ func TestExtractTimings_EmptyData(t *testing.T) {
 	perfData := map[string]interface{}{}
 	timings := extractTimings(perfData, 100)
 
-	// All timings should be 0 except total duration
-	if timings.DNSLookupMs != 0 {
-		t.Errorf("Expected DNS lookup 0ms for empty data, got %d", timings.DNSLookupMs)
+	// All timings should be nil for empty data (not 0)
+	if timings.DNSLookupMs != nil {
+		t.Errorf("Expected DNS lookup nil for empty data, got %v", timings.DNSLookupMs)
 	}
 	if timings.TotalDurationMs != 100 {
 		t.Errorf("Expected total duration 100ms, got %d", timings.TotalDurationMs)
@@ -198,16 +198,16 @@ func TestExtractTimings_PartialData(t *testing.T) {
 	timings := extractTimings(perfData, 200)
 
 	// TTFB should be calculated correctly
-	if timings.TimeToFirstByteMs != 70 {
-		t.Errorf("Expected TTFB 70ms, got %d", timings.TimeToFirstByteMs)
+	if timings.TimeToFirstByteMs == nil || *timings.TimeToFirstByteMs != 70 {
+		t.Errorf("Expected TTFB 70ms, got %v", timings.TimeToFirstByteMs)
 	}
 
-	// Missing fields should be 0
-	if timings.DNSLookupMs != 0 {
-		t.Errorf("Expected DNS lookup 0ms for missing data, got %d", timings.DNSLookupMs)
+	// Missing fields should be nil
+	if timings.DNSLookupMs != nil {
+		t.Errorf("Expected DNS lookup nil for missing data, got %v", timings.DNSLookupMs)
 	}
-	if timings.TCPConnectionMs != 0 {
-		t.Errorf("Expected TCP connection 0ms for missing data, got %d", timings.TCPConnectionMs)
+	if timings.TCPConnectionMs != nil {
+		t.Errorf("Expected TCP connection nil for missing data, got %v", timings.TCPConnectionMs)
 	}
 }
 
@@ -225,12 +225,13 @@ func TestExtractTimings_ZeroValues(t *testing.T) {
 
 	timings := extractTimings(perfData, 50)
 
-	// All durations should be 0 when start/end are the same
-	if timings.DNSLookupMs != 0 {
-		t.Errorf("Expected DNS lookup 0ms for zero values, got %d", timings.DNSLookupMs)
+	// All durations should be nil when end values are 0 (not set)
+	// Note: domainLookupEnd is 0, so the condition `if domainLookupEnd > 0` fails
+	if timings.DNSLookupMs != nil {
+		t.Errorf("Expected DNS lookup nil for zero values, got %v", timings.DNSLookupMs)
 	}
-	if timings.TCPConnectionMs != 0 {
-		t.Errorf("Expected TCP connection 0ms for zero values, got %d", timings.TCPConnectionMs)
+	if timings.TCPConnectionMs != nil {
+		t.Errorf("Expected TCP connection nil for zero values, got %v", timings.TCPConnectionMs)
 	}
 }
 
@@ -247,12 +248,12 @@ func TestExtractTimings_InvalidTypes(t *testing.T) {
 
 	// Function is resilient - invalid types default to 0, valid values are used
 	// So DNS = 10.5 - 0 = 10ms (still calculates correctly with valid end value)
-	if timings.DNSLookupMs != 10 {
-		t.Errorf("Expected DNS lookup 10ms (invalid start=0, valid end=10.5), got %d", timings.DNSLookupMs)
+	if timings.DNSLookupMs == nil || *timings.DNSLookupMs != 10 {
+		t.Errorf("Expected DNS lookup 10ms (invalid start=0, valid end=10.5), got %v", timings.DNSLookupMs)
 	}
 	// TCP = 50.2 - 0 = 50ms (still calculates correctly with valid end value)
-	if timings.TCPConnectionMs != 50 {
-		t.Errorf("Expected TCP connection 50ms (nil start=0, valid end=50.2), got %d", timings.TCPConnectionMs)
+	if timings.TCPConnectionMs == nil || *timings.TCPConnectionMs != 50 {
+		t.Errorf("Expected TCP connection 50ms (nil start=0, valid end=50.2), got %v", timings.TCPConnectionMs)
 	}
 }
 
@@ -269,11 +270,11 @@ func TestExtractTimings_NegativeValues(t *testing.T) {
 	timings := extractTimings(perfData, 100)
 
 	// Should calculate negative duration (indicates data issue)
-	if timings.DNSLookupMs != -5 {
-		t.Errorf("Expected DNS lookup -5ms for reversed values, got %d", timings.DNSLookupMs)
+	if timings.DNSLookupMs == nil || *timings.DNSLookupMs != -5 {
+		t.Errorf("Expected DNS lookup -5ms for reversed values, got %v", timings.DNSLookupMs)
 	}
-	if timings.TimeToFirstByteMs != -5 {
-		t.Errorf("Expected TTFB -5ms for reversed values, got %d", timings.TimeToFirstByteMs)
+	if timings.TimeToFirstByteMs == nil || *timings.TimeToFirstByteMs != -5 {
+		t.Errorf("Expected TTFB -5ms for reversed values, got %v", timings.TimeToFirstByteMs)
 	}
 }
 
@@ -299,23 +300,23 @@ func TestExtractTimings_RealWorldHTTPS(t *testing.T) {
 
 	// Validate extraction logic produces correct values
 	// DNS: 15.3 - 0 = 15ms
-	if timings.DNSLookupMs < 10 || timings.DNSLookupMs > 20 {
-		t.Errorf("DNS lookup outside expected range (10-20ms): %d", timings.DNSLookupMs)
+	if timings.DNSLookupMs == nil || *timings.DNSLookupMs < 10 || *timings.DNSLookupMs > 20 {
+		t.Errorf("DNS lookup outside expected range (10-20ms): %v", timings.DNSLookupMs)
 	}
 
 	// TCP: 45.8 - 15.3 = 30ms (for HTTPS, only until TLS starts)
-	if timings.TCPConnectionMs < 25 || timings.TCPConnectionMs > 35 {
-		t.Errorf("TCP connection outside expected range (25-35ms): %d", timings.TCPConnectionMs)
+	if timings.TCPConnectionMs == nil || *timings.TCPConnectionMs < 25 || *timings.TCPConnectionMs > 35 {
+		t.Errorf("TCP connection outside expected range (25-35ms): %v", timings.TCPConnectionMs)
 	}
 
 	// TLS: 102.7 - 45.8 = 56ms
-	if timings.TLSHandshakeMs < 55 || timings.TLSHandshakeMs > 60 {
-		t.Errorf("TLS handshake outside expected range (55-60ms): %d", timings.TLSHandshakeMs)
+	if timings.TLSHandshakeMs == nil || *timings.TLSHandshakeMs < 55 || *timings.TLSHandshakeMs > 60 {
+		t.Errorf("TLS handshake outside expected range (55-60ms): %v", timings.TLSHandshakeMs)
 	}
 
 	// TTFB: 245.1 - 102.7 = 142ms
-	if timings.TimeToFirstByteMs < 140 || timings.TimeToFirstByteMs > 145 {
-		t.Errorf("TTFB outside expected range (140-145ms): %d", timings.TimeToFirstByteMs)
+	if timings.TimeToFirstByteMs == nil || *timings.TimeToFirstByteMs < 140 || *timings.TimeToFirstByteMs > 145 {
+		t.Errorf("TTFB outside expected range (140-145ms): %v", timings.TimeToFirstByteMs)
 	}
 }
 

--- a/internet-connection-monitor/internal/models/result.go
+++ b/internet-connection-monitor/internal/models/result.go
@@ -42,28 +42,28 @@ type StatusInfo struct {
 
 // TimingMetrics contains all timing measurements in milliseconds
 type TimingMetrics struct {
-	// DNSLookupMs is the time spent resolving DNS
-	DNSLookupMs int64 `json:"dns_lookup_ms"`
+	// DNSLookupMs is the time spent resolving DNS (nil if not available)
+	DNSLookupMs *int64 `json:"dns_lookup_ms,omitempty"`
 
-	// TCPConnectionMs is the time to establish TCP connection
-	TCPConnectionMs int64 `json:"tcp_connection_ms"`
+	// TCPConnectionMs is the time to establish TCP connection (nil if not available)
+	TCPConnectionMs *int64 `json:"tcp_connection_ms,omitempty"`
 
-	// TLSHandshakeMs is the time for TLS negotiation
-	TLSHandshakeMs int64 `json:"tls_handshake_ms"`
+	// TLSHandshakeMs is the time for TLS negotiation (nil if not available)
+	TLSHandshakeMs *int64 `json:"tls_handshake_ms,omitempty"`
 
-	// TimeToFirstByteMs is the time until first byte received
-	TimeToFirstByteMs int64 `json:"time_to_first_byte_ms"`
+	// TimeToFirstByteMs is the time until first byte received (nil if not available)
+	TimeToFirstByteMs *int64 `json:"time_to_first_byte_ms,omitempty"`
 
-	// DOMContentLoadedMs is when the DOM is fully loaded
-	DOMContentLoadedMs int64 `json:"dom_content_loaded_ms"`
+	// DOMContentLoadedMs is when the DOM is fully loaded (nil if not available)
+	DOMContentLoadedMs *int64 `json:"dom_content_loaded_ms,omitempty"`
 
-	// FullPageLoadMs is when the page load event fires
-	FullPageLoadMs int64 `json:"full_page_load_ms,omitempty"`
+	// FullPageLoadMs is when the page load event fires (nil if not available)
+	FullPageLoadMs *int64 `json:"full_page_load_ms,omitempty"`
 
-	// NetworkIdleMs is when network activity has stopped
-	NetworkIdleMs int64 `json:"network_idle_ms,omitempty"`
+	// NetworkIdleMs is when network activity has stopped (nil if not available)
+	NetworkIdleMs *int64 `json:"network_idle_ms,omitempty"`
 
-	// TotalDurationMs is the total time from start to completion
+	// TotalDurationMs is the total time from start to completion (always present)
 	TotalDurationMs int64 `json:"total_duration_ms"`
 }
 

--- a/internet-connection-monitor/internal/outputs/prometheus.go
+++ b/internet-connection-monitor/internal/outputs/prometheus.go
@@ -189,18 +189,18 @@ func (p *PrometheusOutput) Write(result *models.TestResult) error {
 		p.lastSuccessTimestamp.WithLabelValues(siteName).Set(float64(result.Timestamp.Unix()))
 	}
 
-	// Update detailed timing metrics
-	if result.Timings.DNSLookupMs > 0 {
-		p.dnsLookupMs.WithLabelValues(siteName).Set(float64(result.Timings.DNSLookupMs))
+	// Update detailed timing metrics (only if available)
+	if result.Timings.DNSLookupMs != nil {
+		p.dnsLookupMs.WithLabelValues(siteName).Set(float64(*result.Timings.DNSLookupMs))
 	}
-	if result.Timings.TCPConnectionMs > 0 {
-		p.tcpConnectionMs.WithLabelValues(siteName).Set(float64(result.Timings.TCPConnectionMs))
+	if result.Timings.TCPConnectionMs != nil {
+		p.tcpConnectionMs.WithLabelValues(siteName).Set(float64(*result.Timings.TCPConnectionMs))
 	}
-	if result.Timings.TLSHandshakeMs > 0 {
-		p.tlsHandshakeMs.WithLabelValues(siteName).Set(float64(result.Timings.TLSHandshakeMs))
+	if result.Timings.TLSHandshakeMs != nil {
+		p.tlsHandshakeMs.WithLabelValues(siteName).Set(float64(*result.Timings.TLSHandshakeMs))
 	}
-	if result.Timings.TimeToFirstByteMs > 0 {
-		p.timeToFirstByteMs.WithLabelValues(siteName).Set(float64(result.Timings.TimeToFirstByteMs))
+	if result.Timings.TimeToFirstByteMs != nil {
+		p.timeToFirstByteMs.WithLabelValues(siteName).Set(float64(*result.Timings.TimeToFirstByteMs))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Fixes the issue where timeouts/failures were represented as `0ms` in timing fields, causing Grafana dashboards to show misleading latency drops during connection failures.

## Problem

When a timeout or connection failure occurred, all timing breakdown fields (`dns_lookup_ms`, `tcp_connection_ms`, `tls_handshake_ms`, etc.) were set to `0`, which appeared in visualizations as if latency had dropped to 0ms when the connection actually failed.

Example of **before** (failure):
```json
{
  "timings": {
    "dns_lookup_ms": 0,
    "tcp_connection_ms": 0,
    "tls_handshake_ms": 0,
    "total_duration_ms": 86
  }
}
```

## Solution

Changed timing breakdown fields from `int64` to `*int64` (pointers) with `omitempty` JSON tags. Now when data is unavailable, the fields are completely omitted from JSON output rather than showing `0`.

Example of **after** (failure):
```json
{
  "timings": {
    "total_duration_ms": 86
  }
}
```

Successful requests still show all timing fields with actual values:
```json
{
  "timings": {
    "dns_lookup_ms": 15,
    "tcp_connection_ms": 60,
    "tls_handshake_ms": 79,
    "time_to_first_byte_ms": 90,
    "total_duration_ms": 316
  }
}
```

## Changes

- **`internal/models/result.go`**: Changed 7 timing fields to `*int64` with `omitempty` tags (kept `total_duration_ms` as `int64`)
- **`internal/browser/controller_impl.go`**: Added `int64Ptr()` helper and updated timing assignments
- **`internal/outputs/prometheus.go`**: Updated nil checks for pointer types
- **`internal/browser/controller_impl_test.go`**: Updated all tests to handle nullable fields

## Testing

- ✅ All Go tests pass
- ✅ Docker build successful  
- ✅ Manual testing with successful requests shows timing values
- ✅ Manual testing with DNS failures shows timing fields omitted

## Impact

- **Grafana**: Will correctly interpret missing fields instead of showing false "0ms" spikes
- **Elasticsearch**: Schema remains compatible (fields can be absent)
- **Prometheus**: Gauges only set when values are available

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)