### PR TITLE
Secure demo services with localhost-only binding

### DIFF
--- a/internet-connection-monitor/QUICKSTART.md
+++ b/internet-connection-monitor/QUICKSTART.md
@@ -18,11 +18,17 @@ That's it! This single command will:
 
 After 30-60 seconds, visit:
 
-**Grafana Dashboard**: http://localhost:3000
+**Grafana Dashboard**: [http://localhost:3000](http://127.0.0.1:3000/d/internet-conn-mon/internet-connection-monitor?orgId=1&from=now-15m&to=now&timezone=browser&var-site_name=$__all&refresh=1m)
 - Username: `admin`
 - Password: `admin`
 
 The dashboard will be automatically imported and ready to view!
+
+### 🔒 Security Note
+
+All services (Grafana, Elasticsearch, Prometheus) are configured to bind to `127.0.0.1` only, meaning they're **only accessible from your local machine**. This prevents network exposure when running the demo for extended periods.
+
+If you need to access these services from other machines on your network, you can modify the port bindings in `deployments/docker-compose.with-stack.yml` from `127.0.0.1:PORT:PORT` to `0.0.0.0:PORT:PORT` or `PORT:PORT`, but be aware this exposes the services to your network.
 
 ## What You'll See
 

--- a/internet-connection-monitor/README.md
+++ b/internet-connection-monitor/README.md
@@ -43,7 +43,9 @@ make quick-stop     # Stop the monitor
 make grafana-dashboard-demo
 ```
 
-Then visit http://localhost:3000 (admin/admin) to see the dashboard!
+Then visit [http://localhost:3000](http://127.0.0.1:3000/d/internet-conn-mon/internet-connection-monitor?orgId=1&from=now-15m&to=now&timezone=browser&var-site_name=$__all&refresh=1m) (admin/admin) to see the dashboard!
+
+> **🔒 Security Note**: All demo services (Grafana, Elasticsearch, Prometheus) bind to `127.0.0.1` only, preventing network exposure when running for extended periods.
 
 See [QUICKSTART.md](QUICKSTART.md) for details or run `make help` for all commands.
 

--- a/internet-connection-monitor/cmd/monitor/main.go
+++ b/internet-connection-monitor/cmd/monitor/main.go
@@ -91,7 +91,7 @@ func main() {
 		Enabled:       cfg.Advanced.HealthCheckEnabled,
 		Port:          cfg.Advanced.HealthCheckPort,
 		Path:          cfg.Advanced.HealthCheckPath,
-		ListenAddress: "0.0.0.0",
+		ListenAddress: cfg.Advanced.HealthCheckListenAddress,
 	}
 	healthServer, err := health.NewHealthServer(healthCfg)
 	if err != nil {

--- a/internet-connection-monitor/deployments/docker-compose.with-stack.yml
+++ b/internet-connection-monitor/deployments/docker-compose.with-stack.yml
@@ -75,7 +75,7 @@ services:
       - xpack.security.enabled=false
       - xpack.security.enrollment.enabled=false
     ports:
-      - "9200:9200"
+      - "127.0.0.1:9200:9200"
     volumes:
       - es-data:/usr/share/elasticsearch/data
     networks:
@@ -103,7 +103,7 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     volumes:
       - grafana-data:/var/lib/grafana
       - ./grafana-provisioning:/etc/grafana/provisioning
@@ -127,7 +127,7 @@ services:
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
     ports:
-      - "9091:9090"  # 9091 to avoid conflict with monitor's metrics endpoint
+      - "127.0.0.1:9091:9090"  # 9091 to avoid conflict with monitor's metrics endpoint
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus

--- a/internet-connection-monitor/internal/config/config.go
+++ b/internet-connection-monitor/internal/config/config.go
@@ -88,16 +88,17 @@ type PrometheusConfig struct {
 
 // AdvancedConfig contains advanced/debugging settings
 type AdvancedConfig struct {
-	PProfEnabled          bool          `yaml:"pprof_enabled"`
-	PProfPort             int           `yaml:"pprof_port"`
-	HealthCheckEnabled    bool          `yaml:"health_check_enabled"`
-	HealthCheckPort       int           `yaml:"health_check_port"`
-	HealthCheckPath       string        `yaml:"health_check_path"`
-	ShutdownTimeout       time.Duration `yaml:"shutdown_timeout"`
-	MaxConcurrentBrowsers int           `yaml:"max_concurrent_browsers"`
-	CaptureScreenshots    bool          `yaml:"capture_screenshots"`
-	ScreenshotPath        string        `yaml:"screenshot_path"`
-	DNSServers            []string      `yaml:"dns_servers"`
+	PProfEnabled             bool          `yaml:"pprof_enabled"`
+	PProfPort                int           `yaml:"pprof_port"`
+	HealthCheckEnabled       bool          `yaml:"health_check_enabled"`
+	HealthCheckPort          int           `yaml:"health_check_port"`
+	HealthCheckPath          string        `yaml:"health_check_path"`
+	HealthCheckListenAddress string        `yaml:"health_check_listen_address"`
+	ShutdownTimeout          time.Duration `yaml:"shutdown_timeout"`
+	MaxConcurrentBrowsers    int           `yaml:"max_concurrent_browsers"`
+	CaptureScreenshots       bool          `yaml:"capture_screenshots"`
+	ScreenshotPath           string        `yaml:"screenshot_path"`
+	DNSServers               []string      `yaml:"dns_servers"`
 }
 
 // Load loads configuration from file and environment variables
@@ -169,12 +170,13 @@ func DefaultConfig() *Config {
 			LatencyBuckets:   []float64{10, 50, 100, 250, 500, 1000, 2500, 5000, 10000},
 		},
 		Advanced: AdvancedConfig{
-			HealthCheckEnabled:    true,
-			HealthCheckPort:       8080,
-			HealthCheckPath:       "/health",
-			ShutdownTimeout:       30 * time.Second,
-			MaxConcurrentBrowsers: 1,
-			ScreenshotPath:        "/tmp/screenshots",
+			HealthCheckEnabled:       true,
+			HealthCheckPort:          8080,
+			HealthCheckPath:          "/health",
+			HealthCheckListenAddress: "0.0.0.0",
+			ShutdownTimeout:          30 * time.Second,
+			MaxConcurrentBrowsers:    1,
+			ScreenshotPath:           "/tmp/screenshots",
 		},
 	}
 }

--- a/internet-connection-monitor/internal/config/loader.go
+++ b/internet-connection-monitor/internal/config/loader.go
@@ -159,6 +159,10 @@ func LoadFromEnv(cfg *Config) error {
 		}
 	}
 
+	if v := os.Getenv("HEALTH_CHECK_LISTEN_ADDRESS"); v != "" {
+		cfg.Advanced.HealthCheckListenAddress = v
+	}
+
 	return nil
 }
 

--- a/internet-connection-monitor/internal/health/health_test.go
+++ b/internet-connection-monitor/internal/health/health_test.go
@@ -1,0 +1,339 @@
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestNewHealthServer_Disabled tests that nil is returned when disabled
+func TestNewHealthServer_Disabled(t *testing.T) {
+	cfg := &Config{
+		Enabled: false,
+	}
+
+	server, err := NewHealthServer(cfg)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if server != nil {
+		t.Error("Expected nil server when disabled")
+	}
+}
+
+// TestNewHealthServer_DefaultConfig tests creating health server with default config
+func TestNewHealthServer_DefaultConfig(t *testing.T) {
+	cfg := &Config{
+		Enabled:       true,
+		Port:          18080, // Use non-standard port to avoid conflicts
+		Path:          "/health",
+		ListenAddress: "127.0.0.1",
+	}
+
+	server, err := NewHealthServer(cfg)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if server == nil {
+		t.Fatal("Expected server to be created")
+	}
+
+	// Give server a moment to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify server is running
+	resp, err := http.Get("http://127.0.0.1:18080/health")
+	if err != nil {
+		t.Fatalf("Failed to connect to health server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	// Parse response
+	var healthResp HealthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&healthResp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if healthResp.Status != "healthy" {
+		t.Errorf("Expected status 'healthy', got '%s'", healthResp.Status)
+	}
+
+	// Cleanup
+	server.Shutdown()
+}
+
+// TestNewHealthServer_CustomPath tests custom health check path
+func TestNewHealthServer_CustomPath(t *testing.T) {
+	cfg := &Config{
+		Enabled:       true,
+		Port:          18081,
+		Path:          "/custom/healthz",
+		ListenAddress: "127.0.0.1",
+	}
+
+	server, err := NewHealthServer(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer server.Shutdown()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Test custom path
+	resp, err := http.Get("http://127.0.0.1:18081/custom/healthz")
+	if err != nil {
+		t.Fatalf("Failed to connect to health server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+}
+
+// TestNewHealthServer_ListenAddress tests different listen addresses
+func TestNewHealthServer_ListenAddress(t *testing.T) {
+	tests := []struct {
+		name          string
+		listenAddress string
+		testAddress   string
+	}{
+		{
+			name:          "localhost binding",
+			listenAddress: "127.0.0.1",
+			testAddress:   "127.0.0.1",
+		},
+		// Note: We can't easily test 0.0.0.0 binding in unit tests as it would
+		// bind to all interfaces including external ones. In practice, 0.0.0.0
+		// is tested via integration tests.
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Enabled:       true,
+				Port:          18082,
+				Path:          "/health",
+				ListenAddress: tt.listenAddress,
+			}
+
+			server, err := NewHealthServer(cfg)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			defer server.Shutdown()
+
+			time.Sleep(100 * time.Millisecond)
+
+			// Verify server is accessible at the expected address
+			resp, err := http.Get("http://" + tt.testAddress + ":18082/health")
+			if err != nil {
+				t.Fatalf("Failed to connect to health server at %s: %v", tt.testAddress, err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Expected status 200, got %d", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestHealthServer_RecordTest tests recording test results
+func TestHealthServer_RecordTest(t *testing.T) {
+	cfg := &Config{
+		Enabled:       true,
+		Port:          18083,
+		Path:          "/health",
+		ListenAddress: "127.0.0.1",
+	}
+
+	server, err := NewHealthServer(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer server.Shutdown()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Record some test results
+	server.RecordTest(true)
+	server.RecordTest(true)
+	server.RecordTest(false)
+
+	// Check health response
+	resp, err := http.Get("http://127.0.0.1:18083/health")
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var healthResp HealthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&healthResp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if healthResp.TestCount != 3 {
+		t.Errorf("Expected TestCount 3, got %d", healthResp.TestCount)
+	}
+
+	if healthResp.SuccessCount != 2 {
+		t.Errorf("Expected SuccessCount 2, got %d", healthResp.SuccessCount)
+	}
+
+	if healthResp.FailureCount != 1 {
+		t.Errorf("Expected FailureCount 1, got %d", healthResp.FailureCount)
+	}
+}
+
+// TestHealthServer_Shutdown tests graceful shutdown
+func TestHealthServer_Shutdown(t *testing.T) {
+	cfg := &Config{
+		Enabled:       true,
+		Port:          18084,
+		Path:          "/health",
+		ListenAddress: "127.0.0.1",
+	}
+
+	server, err := NewHealthServer(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify server is running
+	_, err = http.Get("http://127.0.0.1:18084/health")
+	if err != nil {
+		t.Fatalf("Server should be running: %v", err)
+	}
+
+	// Shutdown server
+	server.Shutdown()
+
+	// Give it time to shutdown
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify server is no longer accessible
+	_, err = http.Get("http://127.0.0.1:18084/health")
+	if err == nil {
+		t.Error("Expected error connecting to shutdown server")
+	}
+}
+
+// TestHealthServer_StaleTests tests unhealthy status when tests are stale
+func TestHealthServer_StaleTests(t *testing.T) {
+	cfg := &Config{
+		Enabled:       true,
+		Port:          18085,
+		Path:          "/health",
+		ListenAddress: "127.0.0.1",
+	}
+
+	server, err := NewHealthServer(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer server.Shutdown()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Record a test
+	server.RecordTest(true)
+
+	// Manually set last test time to be old (more than 5 minutes ago)
+	server.mu.Lock()
+	server.lastTestTime = time.Now().Add(-6 * time.Minute)
+	server.mu.Unlock()
+
+	// Check health - should be unhealthy due to stale tests
+	resp, err := http.Get("http://127.0.0.1:18085/health")
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("Expected status 503, got %d", resp.StatusCode)
+	}
+
+	var healthResp HealthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&healthResp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if healthResp.Status != "unhealthy" {
+		t.Errorf("Expected status 'unhealthy', got '%s'", healthResp.Status)
+	}
+}
+
+// TestHealthServer_ConcurrentRequests tests handling concurrent health check requests
+func TestHealthServer_ConcurrentRequests(t *testing.T) {
+	cfg := &Config{
+		Enabled:       true,
+		Port:          18086,
+		Path:          "/health",
+		ListenAddress: "127.0.0.1",
+	}
+
+	server, err := NewHealthServer(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer server.Shutdown()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Record some tests
+	for i := 0; i < 10; i++ {
+		server.RecordTest(true)
+	}
+
+	// Make concurrent requests
+	done := make(chan bool)
+	errors := make(chan error, 5)
+
+	for i := 0; i < 5; i++ {
+		go func() {
+			resp, err := http.Get("http://127.0.0.1:18086/health")
+			if err != nil {
+				errors <- err
+				return
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				errors <- nil
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all requests
+	successCount := 0
+	for i := 0; i < 5; i++ {
+		select {
+		case err := <-errors:
+			if err != nil {
+				t.Errorf("Request failed: %v", err)
+			}
+		case <-done:
+			successCount++
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timeout waiting for concurrent requests")
+		}
+	}
+
+	if successCount != 5 {
+		t.Errorf("Expected 5 successful requests, got %d", successCount)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses security concerns when running `make grafana-dashboard-demo` for extended periods by binding all demo services to `127.0.0.1` instead of `0.0.0.0`, preventing network exposure.

## 🔒 Security Improvements

### Services Now Bound to Localhost Only

All Docker services in the demo stack now bind to `127.0.0.1`, making them accessible **only from the local machine**:

- **Grafana** (port 3000): `127.0.0.1:3000:3000`
  - Previously exposed admin/admin credentials and anonymous access to network
- **Elasticsearch** (port 9200): `127.0.0.1:9200:9200`
  - Previously exposed with security disabled to network
- **Prometheus** (port 9091): `127.0.0.1:9091:9090`
  - Previously exposed historical metrics to network

### Monitor Component Unchanged

The internet-monitor component continues to bind to `0.0.0.0` on its ports (9090 for Prometheus metrics, 161 for SNMP, 8080 for health checks). This is intentional because:
- These ports expose metrics/status endpoints (less sensitive than admin interfaces)
- Prometheus container needs to reach the monitor via `host.docker.internal` on Docker Desktop
- Works correctly with host networking architecture

## 📝 Changes

### Configuration
- **docker-compose.with-stack.yml**: Updated port bindings from `PORT:PORT` to `127.0.0.1:PORT:PORT` for Grafana, Elasticsearch, and Prometheus

### Code
- **internal/config/config.go**: Added `HealthCheckListenAddress` field to `AdvancedConfig` struct for future flexibility (defaults to `0.0.0.0`)

### Documentation
- **QUICKSTART.md**: Added security note explaining localhost-only binding and how to expose services if needed
- **README.md**: Added security callout in quick start section

## ✅ Testing

All services continue to work correctly:
- ✅ Grafana can connect to Elasticsearch (both on `monitor-net` bridge network)
- ✅ Prometheus can scrape monitor metrics (via `host.docker.internal`)
- ✅ Monitor can write to Elasticsearch (via localhost:9200)
- ✅ User can access all services from browser at localhost
- ✅ Services are NOT accessible from other machines on the network

## 🎯 Impact

**Before**: Running the demo exposed Grafana (with default credentials), Elasticsearch (security disabled), and Prometheus to the entire network.

**After**: Demo services are only accessible from the local machine, significantly reducing security risk for users running the demo for extended testing or development.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)