### PR TITLE
Fix: Preserve partial timing data on test failures

### DIFF
--- a/internet-connection-monitor/internal/browser/controller_impl.go
+++ b/internet-connection-monitor/internal/browser/controller_impl.go
@@ -163,7 +163,9 @@ func (c *ControllerImpl) TestSite(ctx context.Context, site models.SiteDefinitio
 			ErrorType:    categorizeError(err),
 			ErrorMessage: err.Error(),
 		}
-		result.Timings.TotalDurationMs = totalDuration
+		// Extract whatever timing data is available, even on error
+		// For example, if an HTTP timeout occurs, we may still have DNS and TLS timing data
+		result.Timings = extractTimings(navigationEntry, totalDuration)
 		return result, nil // Return result even on error (for logging)
 	}
 


### PR DESCRIPTION
When a browser test fails (e.g., HTTP timeout), we now extract and preserve any timing data that was successfully collected before the failure. This means if DNS lookup and TLS negotiation succeeded but the HTTP request timed out, we'll still report those timing values.

Previously, only TotalDurationMs was set on error. Now we call extractTimings() to capture all available partial metrics.

The extractTimings function already handles nil and partial data gracefully (verified by existing tests TestExtractTimings_NullData and TestExtractTimings_PartialData).

🤖 Generated with [Claude Code](https://claude.com/claude-code)