### PR TITLE
internet-connection-monitor v1.2.1 - Preserve Partial Timing Data on Failures

### DIFF
--- a/internet-connection-monitor/internal/browser/controller_impl.go
+++ b/internet-connection-monitor/internal/browser/controller_impl.go
@@ -99,7 +99,7 @@ func (c *ControllerImpl) TestSite(ctx context.Context, site models.SiteDefinitio
 		},
 		Metadata: models.TestMetadata{
 			Hostname:  c.hostname,
-			Version:   "1.2.0",
+			Version:   "1.2.1",
 			UserAgent: c.config.UserAgent,
 		},
 	}


### PR DESCRIPTION
## Summary

Patch release to include the fix for preserving partial timing data when browser tests fail.

## 🐛 Bug Fix

- **Preserve partial timing data on test failures** (#16)
  - When a browser test fails (e.g., HTTP timeout), the monitor now extracts and preserves any timing data that was successfully collected before the failure
  - Example: If DNS lookup and TLS negotiation succeeded but the HTTP request timed out, those timing values will still be reported
  - Previously, only `total_duration_ms` was set on error. Now all available partial metrics are captured
  - The `extractTimings()` function handles nil and partial data gracefully (verified by existing tests)

## 📦 Docker Image

After merge, the Docker image will be available at:

```bash
docker pull ghcr.io/nickborgers/internet-connection-monitor:1.2.1
docker pull ghcr.io/nickborgers/internet-connection-monitor:latest
```

### Supported Platforms
- linux/amd64
- linux/arm64

## 📝 Technical Details

**File Changed:**
- `internet-connection-monitor/internal/browser/controller_impl.go` - Calls `extractTimings()` to capture partial metrics even on failure

**Version Bump:**
- Updated version string from `1.2.0` to `1.2.1` in metadata

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)