### PR TITLE
unraid-util v1.0.0 - Add disk management scripts

### DIFF
--- a/unraid-util/Dockerfile
+++ b/unraid-util/Dockerfile
@@ -13,4 +13,11 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/packages.txt && \
     chmod +x /entrypoint.sh
 
+# Install unraid-diskmv scripts (diskmv and consld8) for disk management
+# https://github.com/trinapicot/unraid-diskmv
+RUN git clone --depth 1 https://github.com/trinapicot/unraid-diskmv.git /tmp/unraid-diskmv && \
+    cp /tmp/unraid-diskmv/diskmv /tmp/unraid-diskmv/consld8 /usr/local/bin/ && \
+    chmod +x /usr/local/bin/diskmv /usr/local/bin/consld8 && \
+    rm -rf /tmp/unraid-diskmv
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/unraid-util/README.md
+++ b/unraid-util/README.md
@@ -29,3 +29,39 @@ apt install dnsutils
 
 It's an Ubuntu instance, do what you will.
 
+## Disk Management Scripts
+
+This container includes the [unraid-diskmv](https://github.com/trinapicot/unraid-diskmv) scripts for moving files between disks:
+
+### diskmv
+Move files or directories between disks within a user share:
+```bash
+# Test mode (default - no files moved)
+diskmv /path/to/share disk1 disk2
+
+# Force mode (actually moves files)
+diskmv -f /path/to/share disk1 disk2
+```
+
+Options:
+- `-f` Force execution (default is test mode)
+- `-s SIZE` Only move files larger than SIZE (e.g., `-s 1G`)
+- `-e EXT` Only move files with extension EXT
+- `-c` Clobber/overwrite existing files
+- `-v` Verbose output
+- `-q` Quiet output
+
+### consld8
+Consolidate a user share directory from multiple disks onto a single disk:
+```bash
+# Test mode (default)
+consld8 /path/to/share
+
+# Force mode with specific destination disk
+consld8 -f /path/to/share disk3
+```
+
+If no destination disk is specified, it automatically selects one based on current usage and available space.
+
+**Warning**: These tools move files. Always back up important data before use.
+

--- a/unraid-util/packages.txt
+++ b/unraid-util/packages.txt
@@ -5,3 +5,5 @@ dnsutils
 iproute2
 xxd
 ethtool
+rsync
+git


### PR DESCRIPTION
## Summary

First official release of unraid-util with the new utility-prefixed tagging convention. Adds disk management scripts from [trinapicot/unraid-diskmv](https://github.com/trinapicot/unraid-diskmv).

## 🎉 New Features

### Disk Management Scripts
- **diskmv**: Move files or directories between disks within a user share
- **consld8**: Consolidate directories from multiple disks onto a single disk

Both scripts run in test mode by default (no files moved) and require `-f` flag for actual execution.

## 🔧 Usage

```bash
# Move files from disk1 to disk2 (test mode)
diskmv /path/to/share disk1 disk2

# Force mode (actually moves files)
diskmv -f /path/to/share disk1 disk2

# Consolidate a share onto one disk
consld8 -f /path/to/share disk3
```

## 📦 New Packages

- `rsync` - Required by diskmv scripts for file operations
- `git` - Used during build to clone the scripts

## ⚠️ Note on Docker Hub Tags

Existing Docker Hub tags (`latest`, `v1.5.1`, `v1.5.0`) were artifacts from the old workflow that built all images for any release. This is the first intentional unraid-util release using the new `unraid-util-v*` tagging convention.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)