### PR TITLE
unraid-util v1.1.0 - Add nputop Intel NPU monitoring

### DIFF
--- a/unraid-util/Dockerfile
+++ b/unraid-util/Dockerfile
@@ -20,4 +20,21 @@ RUN git clone --depth 1 https://github.com/trinapicot/unraid-diskmv.git /tmp/unr
     chmod +x /usr/local/bin/diskmv /usr/local/bin/consld8 && \
     rm -rf /tmp/unraid-diskmv
 
+# Install nputop - Intel NPU monitoring tool
+# https://github.com/ZoLArk173/nputop
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl build-essential && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+    . $HOME/.cargo/env && \
+    git clone --depth 1 https://github.com/ZoLArk173/nputop.git /tmp/nputop && \
+    cd /tmp/nputop && \
+    cargo build --release && \
+    cp target/release/nputop /usr/local/bin/ && \
+    chmod +x /usr/local/bin/nputop && \
+    cd / && \
+    rm -rf /tmp/nputop $HOME/.cargo $HOME/.rustup && \
+    apt-get purge -y build-essential && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/unraid-util/README.md
+++ b/unraid-util/README.md
@@ -29,6 +29,18 @@ apt install dnsutils
 
 It's an Ubuntu instance, do what you will.
 
+## Intel NPU Monitoring
+
+This container includes [nputop](https://github.com/ZoLArk173/nputop), a terminal-based monitoring tool for Intel Neural Processing Units (NPUs):
+
+```bash
+nputop
+```
+
+This displays real-time NPU usage similar to how `nvtop` works for NVIDIA GPUs. Useful for monitoring AI/ML workloads on Intel systems with NPU hardware.
+
+**Note**: Requires Intel NPU hardware and appropriate host device passthrough to the container.
+
 ## Disk Management Scripts
 
 This container includes the [unraid-diskmv](https://github.com/trinapicot/unraid-diskmv) scripts for moving files between disks:


### PR DESCRIPTION
## Summary

Add [nputop](https://github.com/ZoLArk173/nputop) to unraid-util for Intel NPU monitoring. This is a terminal-based monitoring tool similar to `nvtop` for NVIDIA GPUs, enabling real-time NPU usage monitoring for AI/ML workloads on Intel systems.

## 🎉 New Features

- **nputop**: Intel Neural Processing Unit (NPU) monitoring tool
  - Real-time NPU usage display
  - Similar interface to nvtop/htop
  - Useful for monitoring AI/ML workloads on Intel hardware

## 🔧 Usage

After starting the unraid-util container:
```bash
docker exec -it util bash
nputop
```

**Note**: Requires Intel NPU hardware and appropriate host device passthrough to the container.

## 📝 Technical Details

- nputop is built from source using Rust/Cargo during the Docker build
- Build dependencies (Rust toolchain, build-essential) are cleaned up after compilation to minimize image size
- Binary installed to `/usr/local/bin/nputop`

## Testing

- [x] Docker build completes successfully
- [x] nputop binary is present at `/usr/local/bin/nputop`
- [x] Binary executes (errors appropriately when no Intel NPU hardware present)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)